### PR TITLE
lwa_antpos.station updates

### DIFF
--- a/lwa_antpos/__init__.py
+++ b/lwa_antpos/__init__.py
@@ -14,7 +14,7 @@ except:
     print('Read antpos from xlsx file in repo')
 
 if 'online' in lwa_df.columns:
-    antnames = lwa_df[lwa_df.online in (True, 'YES')].index
+    antnames = lwa_df[lwa_df.online == True].index
 else:
     antnames = lwa_df.index
 

--- a/lwa_antpos/__init__.py
+++ b/lwa_antpos/__init__.py
@@ -14,7 +14,7 @@ except:
     print('Read antpos from xlsx file in repo')
 
 if 'online' in lwa_df.columns:
-    antnames = lwa_df[lwa_df.online == True].index
+    antnames = lwa_df[lwa_df.online == 'YES'].index
 else:
     antnames = lwa_df.index
 

--- a/lwa_antpos/__init__.py
+++ b/lwa_antpos/__init__.py
@@ -14,7 +14,7 @@ except:
     print('Read antpos from xlsx file in repo')
 
 if 'online' in lwa_df.columns:
-    antnames = lwa_df[lwa_df.online == 'YES'].index
+    antnames = lwa_df[lwa_df.online in (True, 'YES')].index
 else:
     antnames = lwa_df.index
 

--- a/lwa_antpos/station.py
+++ b/lwa_antpos/station.py
@@ -233,9 +233,9 @@ def parse_config(etcdserver=None, filename=None):
                     ant = Antenna.from_line(line)
                     st.append(ant)
     else:
-        df_ant = DataFrame.from_dict(lwa_cnf.get('ant'), orient='index')
-        st = Station.from_df(df_ant)
-                
+        connected = lwa_df[lwa_df.pola_fpga_num != -1]
+        st = Station.from_df(connected)
+        
     return st
 
 

--- a/lwa_antpos/station.py
+++ b/lwa_antpos/station.py
@@ -55,7 +55,8 @@ class Station(object):
 
     @classmethod
     def from_df(cls, df):
-        st = cls('ovro', ovro_lat, ovro_lon, ovro_elev)
+        # TODO: Use OVRO_MMA as the telescope name until CASA knows about OVRO-LWA
+        st = cls('OVRO_MMA', ovro_lat, ovro_lon, ovro_elev)
 
         for antname in antnames:
             row = df.loc[antname]

--- a/lwa_antpos/station.py
+++ b/lwa_antpos/station.py
@@ -218,7 +218,7 @@ def parse_config(etcdserver=None, filename=None):
     """
 
     # TODO: Use OVRO_MMA as the telescope name until CASA knows about OVRO-LWA
-    st = Station('OVRO_MMA')
+    st = Station('OVRO_MMA', ovro_lat, ovro_lon, ovro_elev)
 
     if etcdserver is not None:
         pass

--- a/lwa_antpos/station.py
+++ b/lwa_antpos/station.py
@@ -213,7 +213,8 @@ def parse_config(etcdserver=None, filename=None):
     Can optionally get data from etcd server or static file.
     """
 
-    st = Station('ovro')
+    # Use OVRO_MMA as the telescope name until CASA knows about OVRO-LWA
+    st = Station('OVRO_MMA')
 
     if etcdserver is not None:
         pass

--- a/lwa_antpos/station.py
+++ b/lwa_antpos/station.py
@@ -160,7 +160,9 @@ class Antenna(object):
         """
         lat = float(row.latitude) * numpy.pi/180
         lon = float(row.longitude) * numpy.pi/180
-        elev = 1222.0        # Is this right?
+        elev = float(row.elevation)
+        if elev > 999990:
+            elev = 1222.0
         return cls(row.name, lat, lon, elev)
         
     @classmethod
@@ -172,6 +174,7 @@ class Antenna(object):
         name, lat, lon, x, y, active = line.split(None, 5)
         lat = float(lat) * numpy.pi/180
         lon = float(lon) * numpy.pi/180
+        elev = 1222.0   # TODO: This will need to come from somewhere
         return cls(name, lat, lon, elev)
         
     @property

--- a/lwa_antpos/station.py
+++ b/lwa_antpos/station.py
@@ -58,8 +58,8 @@ class Station(object):
         # TODO: Use OVRO_MMA as the telescope name until CASA knows about OVRO-LWA
         st = cls('OVRO_MMA', ovro_lat, ovro_lon, ovro_elev)
 
-        for antname in antnames:
-            row = df.loc[antname]
+        for corr_num in range(352):
+            row = df[df.corr_num == corr_num].iloc[0]
             ant = Antenna.from_df(row)
             st.append(ant)
 
@@ -234,8 +234,7 @@ def parse_config(etcdserver=None, filename=None):
                     ant = Antenna.from_line(line)
                     st.append(ant)
     else:
-        connected = lwa_df[lwa_df.pola_fpga_num != -1]
-        st = Station.from_df(connected)
+        st = Station.from_df(lwa_df)
         
     return st
 

--- a/lwa_antpos/station.py
+++ b/lwa_antpos/station.py
@@ -112,6 +112,19 @@ class Station(object):
         return (e.x.to_value(u.m), e.y.to_value(u.m), e.z.to_value(u.m))
         
     @property
+    def topo_rot_matrix(self):
+        """
+        Return the rotation matrix that takes a difference in an Earth centered,
+        Earth fixed location relative to the Station and rotates it into a
+        topocentric frame that is south-east-zenith.
+        """
+        
+        r = numpy.array([[ numpy.sin(self.lat)*numpy.cos(self.lon), numpy.sin(self.lat)*numpy.sin(self.lon), -numpy.cos(self.lat)],
+                         [-numpy.sin(self.lon),                     numpy.cos(self.lon),                      0                  ],
+                         [ numpy.cos(self.lat)*numpy.cos(self.lon), numpy.cos(self.lat)*numpy.sin(self.lon),  numpy.sin(self.lat)]])
+        return r
+        
+    @property
     def casa_position(self):
         """
         Return a four-element tuple of (CASA position reference, CASA position 1,
@@ -169,6 +182,28 @@ class Antenna(object):
         
         e = EarthLocation(lat=self.lat*u.rad, lon=self.lon*u.rad, height=self.elev*u.m)
         return (e.x.to_value(u.m), e.y.to_value(u.m), e.z.to_value(u.m))
+        
+    @property
+    def enz(self):
+        """
+        Return the topocentric east-north-zenith coordinates for the antenna 
+        relative to the center of its associated Station in meters.
+        """
+        
+        if self.parent is None:
+            raise RuntimeError("Cannot find east-north-zenith without an associated Station")
+            
+        ecefFrom = numpy.array(self.parent.ecef)
+        ecefTo = numpy.array(self.ecef)
+
+        rho = ecefTo - ecefFrom
+        rot = self.parent.topo_rot_matrix
+        sez = numpy.dot(rot, rho)
+
+        # Convert from south, east, zenith to east, north, zenith
+        enz = 1.0*sez[[1,0,2]]
+        enz[1] *= -1.0
+        return enz
         
     
 def parse_config(etcdserver=None, filename=None):

--- a/lwa_antpos/station.py
+++ b/lwa_antpos/station.py
@@ -213,7 +213,7 @@ def parse_config(etcdserver=None, filename=None):
     Can optionally get data from etcd server or static file.
     """
 
-    # Use OVRO_MMA as the telescope name until CASA knows about OVRO-LWA
+    # TODO: Use OVRO_MMA as the telescope name until CASA knows about OVRO-LWA
     st = Station('OVRO_MMA')
 
     if etcdserver is not None:


### PR DESCRIPTION
This PR does a few things:
 * Adds antenna elevation information.
 * Adds a new `enz` property to `station.Antenna` that returns topocentric coordinates relative to the center of the station.
 * Update `station.parse_config()` to use `lwa_antpos.lwa_df` to population the `Station` if no other parameters are given.
 * Change `station.Station` so that the antennas are ordered in "correlator input" number.
 * Change the station name to "OVRO_MMA" to make CASA happy.